### PR TITLE
Update share-rh7.json

### DIFF
--- a/nodes/share-rh7.json
+++ b/nodes/share-rh7.json
@@ -2,7 +2,7 @@
     "name": "share",
     "yum" : {
       "atrpms" : {
-        "baseurl" : "https://www.mirrorservice.org/sites/dl.atrpms.net/sl$releasever-$basearch/atrpms/stable"
+        "baseurl" : "https://www.mirrorservice.org/sites/dl.atrpms.net/sl7-$basearch/atrpms/stable"
       }
     },
     "artifact-deployer" : {


### PR DESCRIPTION
fixed to use the proper url without $releasever, the correct URL is: https://www.mirrorservice.org/sites/dl.atrpms.net/sl7-x86_64/atrpms/stable/repodata/repomd.xml instead of https://www.mirrorservice.org/sites/dl.atrpms.net/sl7Server-x86_64/atrpms/stable/repodata/repomd.xml