### PR TITLE
Update share-rh7.json

### DIFF
--- a/nodes/share-rh7.json
+++ b/nodes/share-rh7.json
@@ -28,7 +28,7 @@
         "public_portssl" : "80",
         "log.json.enabled" : false,
         "install_fonts" : false,
-        "version" : "5.0.2.5",
+        "version" : "5.0.2",
         "edition" : "enterprise",
         "components" : ["haproxy","nginx","tomcat","transform","repo","share","aos","googledocs"],
         "restart_services" : ["tomcat-alfresco","tomcat-share"],


### PR DESCRIPTION
Alfresco 5.0.2.5 artifacts can't be downloaded with the trial user, right permissions have to be applied to all artifacts like we did for 5.0.2.