### PR TITLE
Update solr-rh7.json

### DIFF
--- a/nodes/solr-rh7.json
+++ b/nodes/solr-rh7.json
@@ -23,7 +23,7 @@
         "public_hostname" : "@@FQDN@@",
         "log.json.enabled" : false,
         "install_fonts" : false,
-        "version" : "5.0.2.5",
+        "version" : "5.0.2",
         "edition" : "enterprise",
         "components" : ["tomcat","repo","transform","solr"],
         "restart_services" : ["tomcat-alfresco","tomcat-solr"],


### PR DESCRIPTION
Alfresco 5.0.2.5 artifacts can't be downloaded with the trial user, right permissions have to be applied to all artifacts like we did for 5.0.2.