### PR TITLE
redeploy on enterprise will make the service starts

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -107,6 +107,7 @@ suites:
   - name: enterprise
     run_list:
       - recipe[alfresco::default]
+      - recipe[alfresco::redeploy]
     data_bags_path: "test/integration/data_bags"
     attributes: {
       "name": "img-basic-test",


### PR DESCRIPTION
As toni pointed on https://issues.alfresco.com/jira/browse/TAA-590 , the enterprise suite on .kitchen.yml is missing the redeploy recipe, which enable and start nginx.

