### PR TITLE
support and configuration for memcached_nodes

### DIFF
--- a/attributes/tomcat.rb
+++ b/attributes/tomcat.rb
@@ -17,6 +17,8 @@ default['tomcat']['restart_action'] = :nothing
 default["tomcat"]["deploy_manager_apps"] = false
 default["tomcat"]["use_security_manager"] = false
 
+default["tomcat"]["memcached_nodes"] = ""
+
 # https://github.com/abrt/abrt/wiki/ABRT-Project
 # http://tomcat.apache.org/download-native.cgi
 # http://tomcat.apache.org/tomcat-7.0-doc/apr.html

--- a/recipes/_tomcat-attributes.rb
+++ b/recipes/_tomcat-attributes.rb
@@ -6,6 +6,27 @@ node.default['artifacts']['catalina-jmx']['type'] = 'jar'
 node.default['artifacts']['catalina-jmx']['destination'] = "#{node['alfresco']['home']}/lib"
 node.default['artifacts']['catalina-jmx']['owner'] = node['alfresco']['user']
 
+node.default['artifacts']['memcached-session-manager']['groupId'] = "de.javakaffee.msm"
+node.default['artifacts']['memcached-session-manager']['artifactId'] = "memcached-session-manager"
+node.default['artifacts']['memcached-session-manager']['version'] = "1.9.2"
+node.default['artifacts']['memcached-session-manager']['type'] = 'jar'
+node.default['artifacts']['memcached-session-manager']['destination'] = "#{node['alfresco']['home']}/lib"
+node.default['artifacts']['memcached-session-manager']['owner'] = node['alfresco']['user']
+
+node.default['artifacts']['memcached-session-manager-tc7']['groupId'] = "de.javakaffee.msm"
+node.default['artifacts']['memcached-session-manager-tc7']['artifactId'] = "memcached-session-manager-tc7"
+node.default['artifacts']['memcached-session-manager-tc7']['version'] = "1.9.2"
+node.default['artifacts']['memcached-session-manager-tc7']['type'] = 'jar'
+node.default['artifacts']['memcached-session-manager-tc7']['destination'] = "#{node['alfresco']['home']}/lib"
+node.default['artifacts']['memcached-session-manager-tc7']['owner'] = node['alfresco']['user']
+
+node.default['artifacts']['spymemcached']['groupId'] = "net.spy"
+node.default['artifacts']['spymemcached']['artifactId'] = "spymemcached"
+node.default['artifacts']['spymemcached']['version'] = "2.11.1"
+node.default['artifacts']['spymemcached']['type'] = 'jar'
+node.default['artifacts']['spymemcached']['destination'] = "#{node['alfresco']['home']}/lib"
+node.default['artifacts']['spymemcached']['owner'] = node['alfresco']['user']
+
 node.default['tomcat']['jvm_route'] = "alfresco-#{node['alfresco']['public_hostname']}"
 
 node.default['tomcat']['global_templates'] = [{

--- a/recipes/tomcat.rb
+++ b/recipes/tomcat.rb
@@ -5,6 +5,12 @@ node.default['artifacts']['alfresco-mmt']['enabled'] = true
 node.default['artifacts']['sharedclasses']['enabled'] = true
 node.default['artifacts']['catalina-jmx']['enabled'] = true
 
+if node['alfresco']['components'].include?("share") && !node["tomcat"]["memcached_nodes"].empty?
+  node.default['artifacts']['memcached-session-manager']['enabled'] = true
+  node.default['artifacts']['memcached-session-manager-tc7']['enabled'] = true
+  node.default['artifacts']['spymemcached']['enabled'] = true
+end
+
 context_template_cookbook = node['tomcat']['context_template_cookbook']
 context_template_source = node['tomcat']['context_template_source']
 
@@ -55,6 +61,15 @@ template "#{node['alfresco']['home']}/conf/context.xml" do
   owner node['alfresco']['user']
   group node['tomcat']['group']
 end
+
+if node['alfresco']['components'].include?("share") && !node["tomcat"]["memcached_nodes"].empty?
+  template "#{node['alfresco']['home']}/conf/Catalina/localhost/share.xml" do
+    source 'tomcat/share.xml.erb'
+    owner node['alfresco']['user']
+    owner node['tomcat']['group']
+  end
+end
+
 
 file_replace_line 'patch-tomcat-conf-javahome' do
   path      '/etc/tomcat/tomcat.conf'

--- a/recipes/tomcat.rb
+++ b/recipes/tomcat.rb
@@ -62,12 +62,12 @@ template "#{node['alfresco']['home']}/conf/context.xml" do
   group node['tomcat']['group']
 end
 
-if node['alfresco']['components'].include?("share") && !node["tomcat"]["memcached_nodes"].empty?
-  template "#{node['alfresco']['home']}/conf/Catalina/localhost/share.xml" do
-    source 'tomcat/share.xml.erb'
-    owner node['alfresco']['user']
-    owner node['tomcat']['group']
-  end
+
+template "#{node['alfresco']['home']}/conf/Catalina/localhost/share.xml" do
+  source 'tomcat/share.xml.erb'
+  owner node['alfresco']['user']
+  owner node['tomcat']['group']
+  only_if node['alfresco']['components'].include?("share") && !node["tomcat"]["memcached_nodes"].empty?
 end
 
 

--- a/templates/default/tomcat/share.xml.erb
+++ b/templates/default/tomcat/share.xml.erb
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context path="/share" reloadable="true" >
+
+    <Manager className="de.javakaffee.web.msm.MemcachedBackupSessionManager"
+      memcachedNodes="<%= node['tomcat']['memcached_nodes'] %>"
+        requestUriIgnorePattern=".*\.(ico|png|gif|jpg|css|js)$"
+        transcoderFactoryClass="de.javakaffee.web.msm.serializer.kryo.KryoTranscoderFactory"
+        />
+</Context>


### PR DESCRIPTION
Referring https://issues.alfresco.com/jira/browse/TAA-657

This PR introduces a new setting: node["tomcat"]["memcached_nodes"].
By default is an empty string, but if set (and 'share' appear in the components list) , the following will happen:
 - /usr/share/tomcat/conf/Catalina/localhost/share.xml will be created, with the memcached_nodes specified as argument
 - spymemcached, memcached-session-manager and memcached-session-manager-tc7  jars will be downloaded in /usr/share/tomcat/lib/