### PR TITLE
allow aos to be enabled on any alfresco version

### DIFF
--- a/recipes/aos.rb
+++ b/recipes/aos.rb
@@ -1,6 +1,4 @@
 node.default['artifacts']['_vti_bin']['enabled'] = true
 node.default['artifacts']['ROOT']['enabled'] = true
 
-if node['alfresco']['version'].start_with?("5.1")
-  node.default['artifacts']['aos-module']['enabled'] = true
-end
+node.default['artifacts']['aos-module']['enabled'] = true


### PR DESCRIPTION
this recipe is added just when the AOS component is present. So just don't insert the component if Alfresco should not have it