### PR TITLE
remove rpmforge from our list

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -26,7 +26,7 @@ depends "java", ">= 1.31.0"
 depends "libreoffice", ">= 0.0.2"
 depends 'line', '>= 0.6.2'
 depends "logstash-forwarder", '>= 0.1.1'
-depends "mysql", ">= 6.0.21"
+depends 'mysql', '~> 7.2'
 depends 'mysql2_chef_gem', ">= 1.0.1"
 depends "nginx", ">= 2.7.6"
 depends "openssl", ">= 4.0.0"
@@ -34,5 +34,4 @@ depends "postgresql", ">= 3.4.18"
 depends 'rsyslog', ">= 1.15.0"
 depends "swftools", ">= 0.2.4"
 depends 'yum-epel'
-depends 'yum-repoforge', ">= 0.5.1"
 depends 'yum-atrpms', ">= 0.1.0"

--- a/recipes/package-repositories.rb
+++ b/recipes/package-repositories.rb
@@ -1,4 +1,3 @@
 if node['platform_family'] == "rhel"
   include_recipe 'yum-epel::default'
-  include_recipe 'yum-repoforge::default'
 end

--- a/test/integration/ci/serverspec/daemons_spec.rb
+++ b/test/integration/ci/serverspec/daemons_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 # Configure Bamboo build to run kitchen converge && kitchen verify || kitchen converge && kitchen verify, avoid folder purging, run on commit; also check with kitchen list if any box is running; every friday evening, run a kitchen destroy && kitchen converge || kitchen converge
 
 services = ['tomcat-alfresco','tomcat-share','tomcat-solr','haproxy','nginx']
-yumrepos = ['epel','nginx','rpmforge','rpmforge-extras','atrpms']
+yumrepos = ['epel','nginx','atrpms']
 
 # TODO - should be the FQDN, but still need to configure /etc/hosts to get this to work
 # alfresco_host = "chef-alfresco-testing.alfresco.test"


### PR DESCRIPTION
turns out that chef-alfresco is not using rpmforge in this project.
Removing it totally produced the same results , both in chef-alfresco and several internal projects.
