### PR TITLE
haproxy component fix

### DIFF
--- a/templates/default/haproxy/haproxy-discovery.json.erb
+++ b/templates/default/haproxy/haproxy-discovery.json.erb
@@ -3,6 +3,9 @@
     "tomcat" : {
       "jvm_route" : "<%= node['tomcat']['jvm_route'] %>"
     },
+    "alfresco": {
+       "components": <%= node['alfresco']['components'] %>
+    },
     "haproxy" : {
       "ec2" : {
         "discovery_enabled" : true

--- a/templates/default/haproxy/haproxy-discovery.json.erb
+++ b/templates/default/haproxy/haproxy-discovery.json.erb
@@ -6,11 +6,7 @@
     "alfresco": {
        "components": <%= node['alfresco']['components'] %>
     },
-    "haproxy" : {
-      "ec2" : {
-        "discovery_enabled" : true
-      }
-    },
+    "haproxy" : <%= node['haproxy'] %>,
     "commons" : {
         "ec2_discovery" : <%= node['commons']['ec2_discovery'].to_json %>
     },

--- a/templates/default/haproxy/haproxy-discovery.json.erb
+++ b/templates/default/haproxy/haproxy-discovery.json.erb
@@ -4,9 +4,14 @@
       "jvm_route" : "<%= node['tomcat']['jvm_route'] %>"
     },
     "alfresco": {
-       "components": <%= node['alfresco']['components'] %>
+      "components": <%= node['alfresco']['components'] %>
     },
-    "haproxy" : <%= node['haproxy'] %>,
+    "haproxy" : {
+      "logformat" : <%= node['haproxy']['logformat'].to_json %>,
+      "ec2": {
+        "discovery_enabled" : true
+      }
+     },
     "commons" : {
         "ec2_discovery" : <%= node['commons']['ec2_discovery'].to_json %>
     },


### PR DESCRIPTION
The problem with haproxy on master is not the configuration, but the haproxy-discovery cron job.

Problem is - to specify which haproxy configuration to use, it needs the list of components.

If not, it will configure all the default ones. By repeating the list here, it will generate a correct configuration