### PR TITLE
removing escapes from the selinux command

### DIFF
--- a/recipes/mysql-local-server.rb
+++ b/recipes/mysql-local-server.rb
@@ -31,8 +31,8 @@ end
 # end
 
 selinux_commands = {}
-selinux_commands['mkdir -p /var/lib/mysql-default ; semanage fcontext -a -t mysqld_db_t \"/var/lib/mysql-default(/.*)?\" ; restorecon -Rv /var/lib/mysql-default;']  = 'ls -lZ /var/lib/mysql-default | grep mysqld_db_t'
-selinux_commands['mkdir -p /var/log/mysql-default ; semanage fcontext -a -t mysqld_log_t \"/var/log/mysql-default(/.*)?\" ; restorecon -Rv /var/log/mysql-default;'] = 'ls -lZ /var/log/mysql-default | grep mysqld_log_t'
+selinux_commands['mkdir -p /var/lib/mysql-default ; semanage fcontext -a -t mysqld_db_t "/var/lib/mysql-default(/.*)?" ; restorecon -Rv /var/lib/mysql-default;']  = 'ls -lZ /var/lib/mysql-default | grep mysqld_db_t'
+selinux_commands['mkdir -p /var/log/mysql-default ; semanage fcontext -a -t mysqld_log_t "/var/log/mysql-default(/.*)?" ; restorecon -Rv /var/log/mysql-default;'] = 'ls -lZ /var/log/mysql-default | grep mysqld_log_t'
 # TODO: - add nginx 2100 port rule => into nginx.rb
 
 # TODO: - make it a custom resource


### PR DESCRIPTION
Seems that after we removed the build-essential , this recipe was giving problems in other internal projects.
After [some research](https://unix.stackexchange.com/questions/151911/syntax-error-near-unexpected-token) i found out that naturally Centos bash works in POSIX mode, and this doesn't support process substitution. Build essential was recompiling gcc, enabling de-facto the process substitution in the bash shell. 
By removing the substitution, everything worked fine again.

This has already been tested in our internal project, which is now unblocked.